### PR TITLE
Remove 'SAV ZIP' option from 'Download data' dropdown

### DIFF
--- a/templates/show.html
+++ b/templates/show.html
@@ -241,7 +241,7 @@
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'zip' %}" class="download__drop-button">ZIP</a>
           <!-- <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'gdoc' %}" class="download__drop-button">GDOCS</a> -->
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'kml'%}"  class="download__drop-button">KML</a>
-          <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'sav_zip' %}" class="download__drop-button">SAV ZIP</a>
+          <!-- a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'sav_zip' %}" class="download__drop-button">SAV ZIP</a> -->
         </div>
       </div>
 


### PR DESCRIPTION
Just an HTML comment, to match the previously removed 'GDOCS' option