### PR TITLE
replace inputs for anonymous users with non-form elements

### DIFF
--- a/static/css/kobo-branding.css
+++ b/static/css/kobo-branding.css
@@ -277,12 +277,18 @@ section {
 
 /* Headers */
 
+ 
 .single-project__header, 
 .projects-list__header, 
 .data-page__header {
   margin-bottom: 30px;
   background-color: white;
   padding:20px 0px;
+  margin-top: -20px;
+}
+
+.sub-header-bar + .single-project__header, 
+.sub-header-bar + .data-page__header {
   padding-top: 70px;
   margin-top: 0px;
 }

--- a/templates/show.html
+++ b/templates/show.html
@@ -147,23 +147,27 @@
   <!-- Project title and background docs -->
   <header class="single-project__header">
       <hgroup class="container">
-        <form>
-            {% csrf_token %}
+        {% if can_edit %}
+          <form>
+          {% csrf_token %}
             <input type="text" id="title" class="input-xxlarge present" value="{{ xform.title }}" />
-            {% if can_edit %}
-              <a id="title_save" data-id="title" href="" class="hidden single-project__button bind-save" data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}">{% trans "save" %}</a>
-            {% endif %}
-        </form>
+            <a id="title_save" data-id="title" href="" class="hidden single-project__button bind-save" data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}">{% trans "save" %}</a>
+          </form>
+        {% else %}
+          <h1>{{ xform.title }}</h1>
+        {% endif %}
 
         <div class="single-project__toggle-documents">
           <i class="fa fa-paperclip"></i> <i class="doctoggle__caret fa fa-caret-right"></i>
-          <form class="single-project__toggle-description">
-            {% csrf_token %}
-            <input type="text" id="description" name="textarea" value="{% if xform.description %}{{ xform.description }}{% endif %}" placeholder="Add a description to your project"/>
-              {% if can_edit %}
+          {% if can_edit %}
+            <form class="single-project__toggle-description">
+              {% csrf_token %}
+              <input type="text" id="description" name="textarea" value="{% if xform.description %}{{ xform.description }}{% endif %}" placeholder="Add a description to your project"/>
                 <a id="description_save" data-id="description" href="" class="hidden single-project__button bind-save" data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}">{% trans "save" %}</a>
-              {% endif %}
-          </form>
+            </form>
+          {% else %}
+            <span>{{ xform.description }}</span>
+          {% endif %}
         </div>
         <div class="single-project__documents hidden">
           <div class="single-project__documents-label">{% trans "Background Documents" %}</div>


### PR DESCRIPTION
Fixes an issue where anonymous users seeing a shared form were being served input fields, whereby they could write on the field. These are now replaced with non-form elements (h1 and div). 