### PR TITLE
Moved Rest Services from the old Ono.io hidden UI to the Form Settings

### DIFF
--- a/static/css/kobo-single-project.css
+++ b/static/css/kobo-single-project.css
@@ -97,6 +97,11 @@ a.settings__files-delete {
   padding:20px;
 }
 
+.settings__rest-services {
+  border-top: 1px solid #D9DDE1;
+  padding:20px;
+}
+
 /* Documents area of single project */
 .single-project__toggle-description {
   display: inline;

--- a/templates/show.html
+++ b/templates/show.html
@@ -78,6 +78,14 @@
 
           </div>
 
+          {% if is_owner %}
+          <div class="settings__rest-services">
+              <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
+              <div id='restservice_tab'>
+              </div>
+          </div>
+          {% endif %}
+
         </div>
 
         <div class="settings__right">


### PR DESCRIPTION
I spoke with Tino through the Support email requesting that we enable REST Services in the Kobocat UI. I added it to the project settings dropdown below the delete button. Next, we will need to rework the CSS in [add-service](https://github.com/kobotoolbox/kobocat/blob/master/onadata/apps/restservice/templates/add-service.html) and [Delete Service Button](https://github.com/kobotoolbox/kobocat/blob/master/onadata/apps/restservice/templates/service.html)