### PR TITLE
Google Sheets export for form data

### DIFF
--- a/templates/export_list.html
+++ b/templates/export_list.html
@@ -66,11 +66,11 @@
           </label>
           {% if export_type == 'gsheets' %}
           <label class="checkbox">
-            <input type="checkbox" name="options[flatten_repeated_fields]" checked="yes" />
+            <input type="checkbox" name="options[flatten_repeated_fields]" />
             {% trans "Flatten repeated groups into a single worksheet." %}
           </label>
           <label class="checkbox">
-            <input type="checkbox" name="options[export_xlsform]" checked="yes" />
+            <input type="checkbox" name="options[export_xlsform]" />
             {% trans "Export the XLSForm along with the survey data." %}
           </label>
           {% endif %}

--- a/templates/export_list.html
+++ b/templates/export_list.html
@@ -29,7 +29,7 @@
             <span style='float:middle;'>
               <div>
                 <input type="submit" class="btn btn-primary" value="{% trans 'New Export' %}" />
-                {% if export_type == 'xls' or export_type == 'csv' %}
+                {% if export_type == 'xls' or export_type == 'csv' or export_type == 'gsheets' %}
                   <a href="#advanced-export-modal" role="button" class="btn" data-toggle="modal">{% trans "Advanced Export" %}</a>
                 {% endif %}
             </div>
@@ -61,9 +61,19 @@
             <option value="/" selected>/ ({% trans "Slash" %})</option>
           </select>
           <label class="checkbox">
-            <input type="checkbox" name="options[dont_split_select_multiples]" value="yes" />
-            {% trans "DONT split select multiple choice answers into separate columns" %}
+            <input type="checkbox" name="options[split_select_multiples]" />
+            {% trans "Split select multiple choice answers into separate columns" %}
           </label>
+          {% if export_type == 'gsheets' %}
+          <label class="checkbox">
+            <input type="checkbox" name="options[flatten_repeated_fields]" checked="yes" />
+            {% trans "Flatten repeated groups into a single worksheet." %}
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="options[export_xlsform]" checked="yes" />
+            {% trans "Export the XLSForm along with the survey data." %}
+          </label>
+          {% endif %}
         </div>
         {% endif %}
         <div class="modal-footer">

--- a/templates/show.html
+++ b/templates/show.html
@@ -245,7 +245,7 @@
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'xls' %}" class="download__drop-button">XLS</a>
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'csv' %}" class="download__drop-button">CSV</a>
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'zip' %}" class="download__drop-button">ZIP</a>
-          <!-- <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'gdoc' %}" class="download__drop-button">GDOCS</a> -->
+          <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'gsheets' %}" class="download__drop-button">Google Sheets</a>
           <a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'kml'%}"  class="download__drop-button">KML</a>
           <a href="{% url "onadata.apps.logger.views.download_excel_analyser" content_user.username xform.id_string %}"  class="download__drop-button">Excel Analyser</a>
           <!-- a href="{% url "onadata.apps.viewer.views.export_list" content_user.username xform.id_string 'sav_zip' %}" class="download__drop-button">SAV ZIP</a> -->


### PR DESCRIPTION
This is the UI part of kobotoolbox/kobocat/pull/71. It enables Google Sheets export in the UI and adds advanced options that are only enabled for this export option.