### PR TITLE
Use static template tag

### DIFF
--- a/static/css/kobo-branding.css
+++ b/static/css/kobo-branding.css
@@ -5,7 +5,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: normal;
-  src: local("Open Sans"), local("OpenSans"), url("/static/fonts/open-sans/opensans-regular.woff2") format("woff2"), url("/static/fonts/open-sans/opensans-regular.woff") format("woff");
+  src: local("Open Sans"), local("OpenSans"), url("../fonts/open-sans/opensans-regular.woff2") format("woff2"), url("../fonts/open-sans/opensans-regular.woff") format("woff");
 }
 
 
@@ -14,7 +14,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
-  src: local("Open Sans Semibold"), local("OpenSans-Semibold"), url("/static/fonts/open-sans/opensans-semibold.woff2") format("woff2"), url("/static/fonts/open-sans/opensans-semibold.woff") format("woff");
+  src: local("Open Sans Semibold"), local("OpenSans-Semibold"), url("../fonts/open-sans/opensans-semibold.woff2") format("woff2"), url("../fonts/open-sans/opensans-semibold.woff") format("woff");
 }
 
 
@@ -23,7 +23,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: normal;
-  src: url("/static/fonts/open-sans/opensans-italic.woff2") format("woff2"), url("/static/fonts/open-sans/opensans-italic.woff") format("woff");
+  src: url("../fonts/open-sans/opensans-italic.woff2") format("woff2"), url("../fonts/open-sans/opensans-italic.woff") format("woff");
 }
 
 
@@ -32,7 +32,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 600;
-  src: url("/static/fonts/open-sans/opensans-semibolditalic.woff2") format("woff2"), url("/static/fonts/open-sans/opensans-semibolditalic.woff") format("woff");
+  src: url("../fonts/open-sans/opensans-semibolditalic.woff2") format("woff2"), url("../fonts/open-sans/opensans-semibolditalic.woff") format("woff");
 }
 
 
@@ -199,7 +199,7 @@ section {
 }
 
 .header-bar__top-logo {
-  background: url(/static/images/kobologo.svg);
+  background: url(../images/kobologo.svg);
   background-size: 120px 27px;
   background-repeat: none;
   width: 120px;

--- a/static/css/kobo-single-project.css
+++ b/static/css/kobo-single-project.css
@@ -504,7 +504,7 @@ span.poshytip {
   width: 300px;
   float: right;
   height: 218px;
-  background: url("/static/images/android_screen.png") center top no-repeat;
+  background: url("../images/android_screen.png") center top no-repeat;
   margin-top: 15px;
   margin-left: 50px;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -18,29 +19,29 @@
     <!-- Le styles -->
     {% block styles %}
 
-    <link rel="icon" type="image/x-icon" href="{{STATIC_URL}}images/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="{% static "images/favicon.ico" %}" />
     <!-- iPhone + iPad icons -->
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{STATIC_URL}}images/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{STATIC_URL}}images/apple-touch-icon-72x72-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" href="{{STATIC_URL}}img/apple-touch-icon-precomposed.png">
-    <link rel="apple-touch-icon" href="{{STATIC_URL}}images/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{% static "images/apple-touch-icon-114x114.png" %}">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{% static "images/apple-touch-icon-72x72-precomposed.png" %}">
+    <link rel="apple-touch-icon-precomposed" href="{% static "img/apple-touch-icon-precomposed.png" %}">
+    <link rel="apple-touch-icon" href="{% static "images/apple-touch-icon.png" %}">
 
-    <link href="{{STATIC_URL}}css/phaseout/bootstrap.min.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/screen.css?v=2809679b01" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/ona-screen-overrides.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/font-awesome.min.css" rel="stylesheet">
+    <link href="{% static "css/phaseout/bootstrap.min.css" %}" rel="stylesheet">
+    <link href="{% static "css/screen.css?v=2809679b01" %}" rel="stylesheet">
+    <link href="{% static "css/ona-screen-overrides.css" %}" rel="stylesheet">
+    <link href="{% static "css/font-awesome.min.css" %}" rel="stylesheet">
     <!--[if lte IE 8]>
-      <link href="{{STATIC_URL}}css/font-awesome-ie7.css" rel="stylesheet">
+      <link href="{% static "css/font-awesome-ie7.css" %}" rel="stylesheet">
     <![endif]-->
-	  <link href="{{STATIC_URL}}bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet">
+	  <link href="{% static "bootstrap/css/bootstrap-responsive.min.css" %}" rel="stylesheet">
 
-    <link href="{{STATIC_URL}}css/kobo-branding.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/published_forms.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/data_pages.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/vex.css" rel="stylesheet">
-    <link href="{{STATIC_URL}}css/vex-theme-kobo.css" rel="stylesheet">
+    <link href="{% static "css/kobo-branding.css" %}" rel="stylesheet">
+    <link href="{% static "css/published_forms.css" %}" rel="stylesheet">
+    <link href="{% static "css/data_pages.css" %}" rel="stylesheet">
+    <link href="{% static "css/vex.css" %}" rel="stylesheet">
+    <link href="{% static "css/vex-theme-kobo.css" %}" rel="stylesheet">
 
-    <link href="{{STATIC_URL}}css/footable.css" rel="stylesheet">
+    <link href="{% static "css/footable.css" %}" rel="stylesheet">
     {% endblock %}
     <!-- spot to insert stuff for google maps -->
     {% block additional-headers %}{% endblock %}
@@ -84,18 +85,18 @@
 
     <!-- Le javascript -->
   <script type="text/javascript" src="{% url "django.views.i18n.javascript_catalog" %}"></script>
-    <script src="{{STATIC_URL}}js/jquery.min.js"></script>
-    <script src="{{STATIC_URL}}js/jquery-migrate.min.js"></script>
-    <script src="{{STATIC_URL}}js/jquery.tablesorter.min.js"></script>
-    <script src="{{STATIC_URL}}bootstrap/js/bootstrap.js"></script>
-    <script src="{{STATIC_URL}}bootstrap/js/bootstrapx-clickover.js"></script>
-    <script src="{{STATIC_URL}}bootstrap/js/bootstrapx-clickover-btns.js"></script>
-    <script src="{{STATIC_URL}}js/application.js?v=201307251039"></script>
-    <script src="{{STATIC_URL}}js/vex.combined.min.js"></script>
+    <script src="{% static "js/jquery.min.js" %}"></script>
+    <script src="{% static "js/jquery-migrate.min.js" %}"></script>
+    <script src="{% static "js/jquery.tablesorter.min.js" %}"></script>
+    <script src="{% static "bootstrap/js/bootstrap.js" %}"></script>
+    <script src="{% static "bootstrap/js/bootstrapx-clickover.js" %}"></script>
+    <script src="{% static "bootstrap/js/bootstrapx-clickover-btns.js" %}"></script>
+    <script src="{% static "js/application.js?v=201307251039" %}"></script>
+    <script src="{% static "js/vex.combined.min.js" %}"></script>
     <script>vex.defaultOptions.className = 'vex-theme-kobo';</script>
-    <script src="{{STATIC_URL}}js/footable.min.js"></script>
+    <script src="{% static "js/footable.min.js" %}"></script>
     <!--  -->
-    <script src="{{STATIC_URL}}js/kobo-branding.js"></script>
+    <script src="{% static "js/kobo-branding.js" %}"></script>
 
     {% endblock %}
 

--- a/templates/data_view.html
+++ b/templates/data_view.html
@@ -1,12 +1,13 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
-<link href="/static/bower_components/backgrid/lib/backgrid.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/static/bower_components/backgrid-filter/backgrid-filter.min.css" />
-<link rel="stylesheet" href="/static/bower_components/backgrid-paginator/backgrid-paginator.min.css" />
-<link href="/static/css/data_view.css" rel="stylesheet">
+<link href="{% static "bower_components/backgrid/lib/backgrid.min.css" %}" rel="stylesheet">
+<link rel="stylesheet" href="{% static "bower_components/backgrid-filter/backgrid-filter.min.css" %}" />
+<link rel="stylesheet" href="{% static "bower_components/backgrid-paginator/backgrid-paginator.min.css" %}" />
+<link href="{% static "css/data_view.css" %}" rel="stylesheet">
 
 <div class="sub-header-bar">
   <div class="container__wide">
@@ -36,16 +37,16 @@
 
 {% block javascript %}
     {{ block.super }}
-    <script type="text/javascript" src="/static/bower_components/underscore/underscore-min.js"></script>
-    <script type="text/javascript" src="/static/bower_components/backbone/backbone-min.js"></script>
-    <script type="text/javascript" src="/static/js/json2.js"></script>
-    <script type="text/javascript" src="/static/bower_components/backgrid/lib/backgrid.js"></script>
-    <script type="text/javascript" src="/static/bower_components/lunr.js/lunr.min.js"></script>
-    <script type="text/javascript" src="/static/bower_components/backbone-pageable/lib/backbone-pageable.min.js"></script>
-    <script type="text/javascript" src="/static/bower_components/backgrid-filter/backgrid-filter.min.js"></script>
-    <script type="text/javascript" src="/static/bower_components/backgrid-paginator/backgrid-paginator.min.js"></script>
-    <script type="text/javascript" src="/static/js/xform.js"></script>
-    <script type="text/javascript" src="/static/js/data_view.js"></script>
+    <script type="text/javascript" src="{% static "bower_components/underscore/underscore-min.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/backbone/backbone-min.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/json2.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/backgrid/lib/backgrid.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/lunr.js/lunr.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/backbone-pageable/lib/backbone-pageable.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/backgrid-filter/backgrid-filter.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "bower_components/backgrid-paginator/backgrid-paginator.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/xform.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/data_view.js" %}"></script>
     <script type="text/javascript">
         var formJSONUrl = "{% url "onadata.apps.logger.views.download_jsonform" owner.username xform.id_string %}";
         var mongoAPIUrl = "{% url "onadata.apps.main.views.api" owner.username xform.id_string %}";

--- a/templates/export_list.html
+++ b/templates/export_list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 
 
 {% block additional-headers %}
@@ -135,11 +136,11 @@
 
 {% block javascript %}
 {{ block.super }}
-<script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.js"></script>
-<script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.pagination.js"></script>
-<script type="text/javascript" src="{{STATIC_URL}}js/form_actions.js"></script>
-<script type="text/javascript" charset="utf-8" src="{{STATIC_URL}}js/underscore-min.js"></script>
-<script type="text/javascript" charset="utf-8" src="{{STATIC_URL}}js/export_list.js"></script>
+<script type="text/javascript" src="{% static "js/jquery.dataTables.js" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery.dataTables.pagination.js" %}"></script>
+<script type="text/javascript" src="{% static "js/form_actions.js" %}"></script>
+<script type="text/javascript" charset="utf-8" src="{% static "js/underscore-min.js" %}"></script>
+<script type="text/javascript" charset="utf-8" src="{% static "js/export_list.js" %}"></script>
 <script type="text/javascript">
     var progress_url = '{% url "onadata.apps.viewer.views.export_progress" username xform.id_string export_type %}';
 </script>

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,6 +1,7 @@
+{% load static %}
 <div class="header">
   <ul class="nav nav-pills pull-right"></ul>
   <a class="brand" href="/" title="KoBoCAT">
-    <img alt="KoBoCAT" src="{{STATIC_URL}}images/kobocat_logo.png" />
+    <img alt="KoBoCAT" src="{% static "images/kobocat_logo.png" %}" />
   </a>
 </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,6 +1,7 @@
 {% extends 'ona_base.html' %}
 {% load humanize %}
 {% load i18n %}
+{% load static %}
 
 {% block styles %}
     {{block.super}}
@@ -50,7 +51,7 @@
 </div>
 <div class="row">
     <div class="col-md-8">
-        <img src="{{STATIC_URL}}images/kobocat_photo.png" width="497" height="363"/>
+        <img src="{% static "images/kobocat_photo.png" %}" width="497" height="363"/>
     </div>
     <div class="col-md-4">
         {% url "auth_login" as login_url %}

--- a/templates/instance.html
+++ b/templates/instance.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
@@ -23,7 +24,7 @@
 {% load i18n %}
 <div id="loading">
   <p> {% trans "Loading..." %} </p>
-  <img id="loading-image" src="{{STATIC_URL}}images/ajax-loader.gif" alt="Loading..." />
+  <img id="loading-image" src="{% static "images/ajax-loader.gif" %}" alt="Loading..." />
 </div>
 {% if messages %}
 <div>{{messages}}</div>
@@ -47,10 +48,10 @@
 
 {% block javascript %}
 {{ block.super }}
-<script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.js"></script>
-<script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.pagination.js"></script>
-<script type="text/javascript" charset="utf-8" src="{{STATIC_URL}}js/sammy-0.7.1.min.js"></script>
-<script type="text/javascript" charset="utf-8" src="{{STATIC_URL}}js/sammy-plugins/sammy.meld-0.7.1.min.js"></script>
+<script type="text/javascript" src="{% static "js/jquery.dataTables.js" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery.dataTables.pagination.js" %}"></script>
+<script type="text/javascript" charset="utf-8" src="{% static "js/sammy-0.7.1.min.js" %}"></script>
+<script type="text/javascript" charset="utf-8" src="{% static "js/sammy-plugins/sammy.meld-0.7.1.min.js" %}"></script>
 
 <script type="text/javascript">
 var formJSONUrl = "{% url "onadata.apps.logger.views.download_jsonform" username id_string %}";
@@ -172,7 +173,7 @@ function _attachment_url(name, size)
 
 </script>
 
-<script type="text/javascript" charset="utf-8" src="{{STATIC_URL}}js/instance.js"></script>
+<script type="text/javascript" charset="utf-8" src="{% static "js/instance.js" %}"></script>
 
 <script type="text/javascript">
 $(document).ready(function(){

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,15 +1,16 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block additional-headers %}
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
 
-<link rel="stylesheet" href="/static/css/leaflet.css?v=0.6.2" />
-<link rel="stylesheet" href="/static/css/leaflet.draw.css?v=0.2.0-dev" />
-<link rel="stylesheet" href="/static/css/map.css" />
+<link rel="stylesheet" href="{% static "css/leaflet.css?v=0.6.2" %}" />
+<link rel="stylesheet" href="{% static "css/leaflet.draw.css?v=0.2.0-dev" %}" />
+<link rel="stylesheet" href="{% static "css/map.css" %}" />
 <!--[if lte IE 8]>
-    <link rel="stylesheet" href="/static/css/leaflet.ie.css?v=0.6.2" />
-    <link rel="stylesheet" href="/static/css/leaflet.draw.ie.css?v=0.2.0-dev" />
+    <link rel="stylesheet" href="{% static "css/leaflet.ie.css?v=0.6.2" %}" />
+    <link rel="stylesheet" href="{% static "css/leaflet.draw.ie.css?v=0.2.0-dev" %}" />
 <![endif]-->
 {% endblock %}
 
@@ -59,17 +60,17 @@
   
 {% block javascript %}
 {{ block.super }}
-<script type="text/javascript" src="/static/js/json2.js"></script>
-<script type="text/javascript" src="/static/js/leaflet.js?v=0.6.2"></script>
-<script type="text/javascript" src="/static/js/leaflet.draw.js?v=0.2.0-dev"></script>
-<script type="text/javascript" src="/static/js/mapbox.standalone.js?v=1.1.0"></script>
-<script type="text/javascript" src="/static/js/custom-button-leaflet.js"></script>
+<script type="text/javascript" src="{% static "js/json2.js" %}"></script>
+<script type="text/javascript" src="{% static "js/leaflet.js?v=0.6.2" %}"></script>
+<script type="text/javascript" src="{% static "js/leaflet.draw.js?v=0.2.0-dev" %}"></script>
+<script type="text/javascript" src="{% static "js/mapbox.standalone.js?v=1.1.0" %}"></script>
+<script type="text/javascript" src="{% static "js/custom-button-leaflet.js" %}"></script>
 <script src="https://maps.google.com/maps/api/js?v=3.2&sensor=false"></script>
-<script type="text/javascript" src="/static/js/Google.js"></script>
-<script type="text/javascript" src="/static/js/wax.leaf.min.js?v=6.4.0"></script>
-<script type="text/javascript" src="/static/js/TileLayer.Bing.js"></script>
-<script type="text/javascript" src="/static/js/formManagers.js?ts=201303251542"></script>
-<script type="text/javascript" src="/static/js/jquery.ba-bbq.min.js"></script>
+<script type="text/javascript" src="{% static "js/Google.js" %}"></script>
+<script type="text/javascript" src="{% static "js/wax.leaf.min.js?v=6.4.0" %}"></script>
+<script type="text/javascript" src="{% static "js/TileLayer.Bing.js" %}"></script>
+<script type="text/javascript" src="{% static "js/formManagers.js?ts=201303251542" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery.ba-bbq.min.js" %}"></script>
 <script type="text/javascript">
   var formJSONUrl = "{{ jsonform_url }}";
   var enketoAddUrl = "{{ enketo_add_url }}";
@@ -282,12 +283,12 @@
   });
 
 </script>
-<script src="/static/js/mapview.js?ts=201311251415" type="text/javascript"></script>
-<script src="/static/js/underscore-min.js" type="text/javascript"></script>
-<script src="/static/js/d3.js" type="text/javascript"></script>
-<script src="/static/js/dv.js" type="text/javascript"></script>
-<script src="/static/js/hex.js" type="text/javascript"></script>
-<script src="/static/js/d3.hexbin.js" type="text/javascript"></script>
+<script src="{% static "js/mapview.js?ts=201311251415" %}" type="text/javascript"></script>
+<script src="{% static "js/underscore-min.js" %}" type="text/javascript"></script>
+<script src="{% static "js/d3.js" %}" type="text/javascript"></script>
+<script src="{% static "js/dv.js" %}" type="text/javascript"></script>
+<script src="{% static "js/hex.js" %}" type="text/javascript"></script>
+<script src="{% static "js/d3.hexbin.js" %}" type="text/javascript"></script>
 {% endblock %}
 </body>
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
@@ -57,8 +58,8 @@
 {% endblock %}
 <!--
   <script type="text/javascript">$('#gravatar').tooltip();</script>
-  <script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.js"></script>
-  <script type="text/javascript" src="{{STATIC_URL}}js/jquery.dataTables.pagination.js"></script>
+  <script type="text/javascript" src="{% static "js/jquery.dataTables.js" %}"></script>
+  <script type="text/javascript" src="{% static "js/jquery.dataTables.pagination.js" %}"></script>
   <script type="text/javascript">
 /*
         $.extend( $.fn.dataTableExt.oStdClasses, {

--- a/templates/rest_framework/api.html
+++ b/templates/rest_framework/api.html
@@ -6,7 +6,7 @@ KoBoCAT REST API
 
 {% block style %}
     {% block bootstrap_theme %}
-        <link href="{{STATIC_URL}}bootstrap/css/bootstrap.min.css" rel="stylesheet">
+        <link href="{% static "bootstrap/css/bootstrap.min.css" %}" rel="stylesheet">
 
         <link href="//netdna.bootstrapcdn.com/font-awesome/3.0/css/font-awesome.css" rel="stylesheet">
         <!--[if lte IE 8]>
@@ -15,7 +15,7 @@ KoBoCAT REST API
         <style type="text/css">
         .header-bar__top-logo {
             display: inline-block;
-            background: url('/static/images/kobologo.svg');
+            background: url('{{STATIC_URL}}images/kobologo.svg');
             background-size: 120px 27px;
             background-repeat: none;
             width: 120px;
@@ -24,11 +24,11 @@ KoBoCAT REST API
             margin-right: 6px;
         }
         </style>
-        <link href="{{STATIC_URL}}bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet">
+        <link href="{% static "bootstrap/css/bootstrap-responsive.min.css" %}" rel="stylesheet">
     {% endblock %}
 
     {{ block.super }}
-    <link href="{{STATIC_URL}}css/screen.css?v=2809679b01" rel="stylesheet">
+    <link href="{% static "css/screen.css?v=2809679b01" %}" rel="stylesheet">
 {% endblock %}
 
 {% block script %}

--- a/templates/rest_framework/api.html
+++ b/templates/rest_framework/api.html
@@ -1,4 +1,6 @@
 {% extends "rest_framework/base.html" %}
+{% load static %}
+
 
 {% block title %}
 KoBoCAT REST API
@@ -15,7 +17,7 @@ KoBoCAT REST API
         <style type="text/css">
         .header-bar__top-logo {
             display: inline-block;
-            background: url('{{STATIC_URL}}images/kobologo.svg');
+            background: url("{% static "images/kobologo.svg" %}");
             background-size: 120px 27px;
             background-repeat: none;
             width: 120px;
@@ -28,7 +30,7 @@ KoBoCAT REST API
     {% endblock %}
 
     {{ block.super }}
-    <link href="{% static "css/screen.css?v=2809679b01" %}" rel="stylesheet">
+    <link href="{% static "css/screen.css" %}" rel="stylesheet">
 {% endblock %}
 
 {% block script %}

--- a/templates/show.html
+++ b/templates/show.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load humanize %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
@@ -777,18 +778,18 @@
 {% block styles %}
 {{ block.super }}
   <!-- NEW SANDBOX STYLES -->
-  <link href="/static/css/ios-switches.css" rel="stylesheet">
-  <link href="/static/css/kobo-single-project.css" rel="stylesheet">
+  <link href="{% static "css/ios-switches.css" %}" rel="stylesheet">
+  <link href="{% static "css/kobo-single-project.css" %}" rel="stylesheet">
   <!-- END NEW SANDBOX STYLES -->
- <!-- <link href="{{STATIC_URL}}css/iphone-btn-style.css" rel="stylesheet"/> -->
+ <!-- <link href="{% static "css/iphone-btn-style.css" %}" rel="stylesheet"/> -->
 {% endblock %}
 
 {% block javascript %}
 {{ block.super }}
-<script src="/static/js/jquery.poshytip.js"></script>
+<script src="{% static "js/jquery.poshytip.js" %}"></script>
   {% if user.is_authenticated %}
-    <script type="text/javascript" src="{{STATIC_URL}}js/form_actions.js"></script>
-    <script type="text/javascript" src="{{STATIC_URL}}js/jquery.cookie.js"></script>
+    <script type="text/javascript" src="{% static "js/form_actions.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/jquery.cookie.js" %}"></script>
   {% endif %}
 
 

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load humanize %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
@@ -189,17 +190,17 @@
 {% block styles %}
 {{ block.super }}
   <!-- NEW SANDBOX STYLES -->
-  <link href="/static/css/ios-switches.css" rel="stylesheet">
-  <link href="/static/css/kobo-single-project.css" rel="stylesheet">
+  <link href="{% static "css/ios-switches.css" %}" rel="stylesheet">
+  <link href="{% static "css/kobo-single-project.css" %}" rel="stylesheet">
   <!-- END NEW SANDBOX STYLES -->
 {% endblock %}
 
 {% block javascript %}
 {{ block.super }}
-<script src="/static/js/jquery.poshytip.js"></script>
+<script src="{% static "js/jquery.poshytip.js" %}"></script>
   {% if user.is_authenticated %}
-    <script type="text/javascript" src="{{STATIC_URL}}js/form_actions.js"></script>
-    <script type="text/javascript" src="{{STATIC_URL}}js/jquery.cookie.js"></script>
+    <script type="text/javascript" src="{% static "js/form_actions.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/jquery.cookie.js" %}"></script>
   {% endif %}
 
 

--- a/templates/stats_tables.html
+++ b/templates/stats_tables.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
 {% load lookup_filter %}
+{% load static %}
 
 {% block additional-headers %}
 {% load i18n %}
-<link rel="stylesheet" href="{{STATIC_URL}}css/stats_tables.css" />
-<link rel="stylesheet" href="{{STATIC_URL}}bower_components/backgrid/lib/backgrid.min.css" />
+<link rel="stylesheet" href="{% static "css/stats_tables.css" %}" />
+<link rel="stylesheet" href="{% static "bower_components/backgrid/lib/backgrid.min.css" %}" />
 
 <div class="sub-header-bar">
   <div class="container__wide">
@@ -76,11 +77,11 @@
 
 {% block javascript %}
 {{ block.super }}
-<script src="{{STATIC_URL}}bower_components/underscore/underscore-min.js"></script>
-<script src="{{STATIC_URL}}bower_components/backbone/backbone-min.js"></script>
-<script src="{{STATIC_URL}}bower_components/backgrid/lib/backgrid.js"></script>
-<script src="{{STATIC_URL}}js/xform.js"></script>
-<script src="{{STATIC_URL}}js/stats_tables.js"></script>
+<script src="{% static "bower_components/underscore/underscore-min.js" %}"></script>
+<script src="{% static "bower_components/backbone/backbone-min.js" %}"></script>
+<script src="{% static "bower_components/backgrid/lib/backgrid.js" %}"></script>
+<script src="{% static "js/xform.js" %}"></script>
+<script src="{% static "js/stats_tables.js" %}"></script>
 <script type="text/javascript">
     var formUrl = "{% url "download_jsonform" xform.user.username xform.id_string %}";
     var statsUrl = "{% url "stats-detail" xform.pk %}";

--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load static %}
 
 <header class="header-bar">
   <div class="container__wide">
@@ -64,7 +65,7 @@
         <span class="icon-bar"></span>
       </a>
       <a class="brand" href="/" title="KoBoCAT"><img alt="KoBoCAT"
-          src="{{STATIC_URL}}images/kobocat_logo.png" style="height: 34px" /></a>
+          src="{% static "images/kobocat_logo.png" %}" style="height: 34px" /></a>
       <div class="nav-collapse collapse">
           {% if form_view %}
           <ul class="nav">


### PR DESCRIPTION
In order to make it easier to use kobocat-template with a kobocat running at a sub-directory url, e.g. app.example.com/kobocat, I have replaced all the `/static/` fixed references and all the `{{ STATIC_URL }} urls with a use of the `{% static %}` template tag as per current Django best practice.