### PR TITLE
Hide old options from Form Settings view

### DIFF
--- a/static/css/kobo-branding.css
+++ b/static/css/kobo-branding.css
@@ -318,7 +318,6 @@ section {
   margin-bottom: 30px;
   background-color: white;
   padding: 20px 0px;
-  margin-top: -20px;
 }
 
 .sub-header-bar + .single-project__header,
@@ -327,11 +326,7 @@ section {
   margin-top: 0px;
 }
 
-.projects-list__header {
-  padding-top: 50px;
-  margin-top: -20px;
-}
-
+.legacy-warning .container,
 .single-project__header .container,
 .projects-list__header .container,
 .data-page__header .container {

--- a/static/css/kobo-branding.css
+++ b/static/css/kobo-branding.css
@@ -409,6 +409,12 @@ td.published_forms__cell--project a:hover {
   color: #1e8fde;
 }
 
+.projects__warning {
+  padding: 10px;
+  border: 1px solid red;
+  background: pink;
+}
+
 .projects__advanced {
   background: white;
   padding: 20px 0px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,6 +51,12 @@
   {% if not user.is_authenticated %}
 
   <body>
+    <div class="legacy-warning">
+      <div class="container">
+        We no longer recommend using the legacy interface. Please access all our new features in the <a href="{{ koboform_url }}">new interface</a> (new map, table, reports, labeled data exports, etc.). If you have deployed your project directly in the legacy interface, there is no way to use these new features. <strong>This legacy interface will be removed shortly.</strong>
+      </div>
+    </div>
+    
     <header class="header-bar">
       <div class="container__wide">
         <span class="header-bar__top-logo pull-right"></span>

--- a/templates/header.html
+++ b/templates/header.html
@@ -5,3 +5,6 @@
     <img alt="KoBoCAT" src="{% static "images/kobocat_logo.png" %}" />
   </a>
 </div>
+<div class="header-warning">
+  We no longer recommend using the legacy interface. Please access all our new features in the <a href="{{ koboform_url }}">new interface</a> (new map, table, reports, labeled data exports, etc.). If you have deployed your project directly in the legacy interface, there is no way to use these new features. <strong>This legacy interface will be removed shortly.</strong>
+</div>

--- a/templates/header.html
+++ b/templates/header.html
@@ -5,6 +5,3 @@
     <img alt="KoBoCAT" src="{% static "images/kobocat_logo.png" %}" />
   </a>
 </div>
-<div class="header-warning">
-  We no longer recommend using the legacy interface. Please access all our new features in the <a href="{{ koboform_url }}">new interface</a> (new map, table, reports, labeled data exports, etc.). If you have deployed your project directly in the legacy interface, there is no way to use these new features. <strong>This legacy interface will be removed shortly.</strong>
-</div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,6 +14,11 @@
         padding-bottom: 15px;
         border-bottom: 1px solid #e5e5e5;
     }
+    .header-warning {
+       padding: 10px;
+       border-bottom: 1px solid red;
+       background: pink;
+    }
     .footer{
         margin-top: 45px;
         padding-top: 15px;

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,10 +14,16 @@
         padding-bottom: 15px;
         border-bottom: 1px solid #e5e5e5;
     }
-    .header-warning {
-       padding: 10px;
-       border-bottom: 1px solid red;
-       background: pink;
+    .legacy-warning {
+        padding: 20px;
+        border-top: 1px solid red;
+        border-bottom: 1px solid red;
+        background: lightpink;
+    }
+    .legacy-warning a {
+        color: darkred;
+        text-decoration: underline;
+        font-weight: bold;
     }
     .footer{
         margin-top: 45px;

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -41,7 +41,12 @@
       </div>
     {% endif %}
 
+    <div class="projects__warning">
+      We no longer recommend deploying projects directly from the legacy interface. You will NOT have access to all our new shiny tools and features, and deploying a project with the legacy interface is highly discouraged at this point. Please use the <a href="{{ koboform_url }}">new interface</a> to deploy your projects. The legacy interface and this deployment feature will be removed shortly.
+    </div>
+
     <h3>Advanced Users: <a class="projects__toggle-advanced">Upload your XLS form here directly</a></h3>
+    
     <div class="projects__advanced-xls hidden-form">
       <form action="." method="post" enctype="multipart/form-data">
         {% csrf_token %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -41,8 +41,10 @@
       </div>
     {% endif %}
 
-    <div class="projects__warning">
-      We no longer recommend deploying projects directly from the legacy interface. You will NOT have access to all our new shiny tools and features, and deploying a project with the legacy interface is highly discouraged at this point. Please use the <a href="{{ koboform_url }}">new interface</a> to deploy your projects. The legacy interface and this deployment feature will be removed shortly.
+    <div class="legacy-warning">
+      <div class="container">
+        We no longer recommend deploying projects directly from the legacy interface. You will NOT have access to all our new shiny tools and features, and deploying a project with the legacy interface is highly discouraged at this point. Please use the <a href="{{ koboform_url }}">new interface</a> to deploy your projects. The legacy interface and this deployment feature will be removed shortly.
+      </div>
     </div>
 
     <h3>Advanced Users: <a class="projects__toggle-advanced">Upload your XLS form here directly</a></h3>

--- a/templates/show.html
+++ b/templates/show.html
@@ -81,7 +81,7 @@
 
           {% if is_owner %}
           <div class="settings__rest-services">
-              <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
+              <h2 class="settings__group-label">{% trans "Legacy Rest Services" %}</h2>
               <div id='restservice_tab'>
               </div>
           </div>
@@ -660,7 +660,7 @@
         {% if is_owner %}
         <br/>
         <div class="clearfix bordered kc-hide">
-            <h3 data-toggle="collapse" class="toggler" data-target="#restservice_tab">{% trans "Rest Services" %}</h3>
+            <h3 data-toggle="collapse" class="toggler" data-target="#restservice_tab">{% trans "Legacy Rest Services" %}</h3>
             <div id='restservice_tab' class="collapse">
             </div>
         </div>

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -14,78 +14,65 @@
 
 {% block content %}
 {% load i18n %}
-
-  <!-- Project title -->
-  <!--   <header class="single-project__header">
-      <hgroup class="container">
-          <h1>{% trans "Settings" %}: {{ xform.title }}</h1>
-      </hgroup>
-  </header>
- -->
   <!-- NEW SANDBOX HTML OUTSIDE THE CONTAINER -->
   {% if is_owner %}
   <div class="container__wide">
     <div class="single-project__settings--iframe">
+      <div class="settings__general">
+        <h2 class="settings__group-label">
+          {% trans "Form Settings" %}
+        </h2>
 
-        <div class="settings__general">
-          <h2 class="settings__group-label">
-            {% trans "Form Settings" %}
-          </h2>
+        <div class="settings__form-item">
+          <label class="settings__form-label">Existing Form Files</label>
+          <ul class="settings__files">
+            {% for media in media_upload %}
+              <li class="{% cycle 'odd' 'even' %}">
+                <div>{{ media.data_value }}</div>
+                <a href="{% url "onadata.apps.main.views.download_media_data" content_user.username xform.id_string media.id %}" class="settings__files-download" {% trans "download" %}><i class="fa fa-download"></i></a>
+                {% if can_edit %}
+                <a href="{% url "onadata.apps.main.views.download_media_data" content_user.username xform.id_string media.id %}?del=true" class="settings__files-delete" title="{% trans "remove" %}"><i class="fa fa-trash-o"></i></a>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
 
-          <div class="settings__form-item">
-            <label class="settings__form-label">Existing Form Files</label>
-            <ul class="settings__files">
-              {% for media in media_upload %}
-                <li class="{% cycle 'odd' 'even' %}">
-                  <div>{{ media.data_value }}</div>
-                  <a href="{% url "onadata.apps.main.views.download_media_data" content_user.username xform.id_string media.id %}" class="settings__files-download" {% trans "download" %}><i class="fa fa-download"></i></a>
-                  {% if can_edit %}
-                  <a href="{% url "onadata.apps.main.views.download_media_data" content_user.username xform.id_string media.id %}?del=true" class="settings__files-delete" title="{% trans "remove" %}"><i class="fa fa-trash-o"></i></a>
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ul>
+          {% if can_edit %}
+          <button class="single-project__button single-project__add-media">+ Add Document</button>
 
-            {% if can_edit %}
-            <button class="single-project__button single-project__add-media">+ Add Document</button>
-
-            <form action="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}" method="post" enctype="multipart/form-data" class="single-project__media-upload hidden">
-                {% csrf_token %}
-                <ul class="nav nav-tabs">
-                    <li class="active"><a href="#media_upload" data-toggle="tab">Media Upload</a></li>
-                    <li><a href="#media_url_add" data-toggle="tab">Media URL</a></li>
-                </ul>
-                <div class="tab-content">
-                    <div class="tab-pane active" id="media_upload">
-                        <input type="file" multiple="" name="media" id="id_media">
-                        <input type="submit" class="single-project__button" value="{% trans 'Upload' %}" />
-                    </div>
-                    <div class="tab-pane" id="media_url_add">
-                        <label for="id_media">Media url:</label>
-                        <input type="text" name="media_url" id="id_media_url">
-                        <input type="submit" class="single-project__button" value="{% trans 'Save Media URL' %}" />
-                    </div>
-                </div>
-            </form>
-            {% endif %}
-          </div>
-
-        </div>  <!-- END .settings__general -->
-
-        {% if is_owner %}
-        <div class="settings__rest-services">
-            <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
-            <div id='restservice_tab'>
-            </div>
+          <form action="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}" method="post" enctype="multipart/form-data" class="single-project__media-upload hidden">
+              {% csrf_token %}
+              <ul class="nav nav-tabs">
+                  <li class="active"><a href="#media_upload" data-toggle="tab">Media Upload</a></li>
+                  <li><a href="#media_url_add" data-toggle="tab">Media URL</a></li>
+              </ul>
+              <div class="tab-content">
+                  <div class="tab-pane active" id="media_upload">
+                      <input type="file" multiple="" name="media" id="id_media">
+                      <input type="submit" class="single-project__button" value="{% trans 'Upload' %}" />
+                  </div>
+                  <div class="tab-pane" id="media_url_add">
+                      <label for="id_media">Media url:</label>
+                      <input type="text" name="media_url" id="id_media_url">
+                      <input type="submit" class="single-project__button" value="{% trans 'Save Media URL' %}" />
+                  </div>
+              </div>
+          </form>
+          {% endif %}
         </div>
-        {% endif %}
+      </div>  <!-- END .settings__general -->
+
+      {% if is_owner %}
+      <div class="settings__rest-services">
+          <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
+          <div id='restservice_tab'>
+          </div>
+      </div>
+      {% endif %}
     </div>
   </div>
   {% endif %}
-
   <!-- END NEW SANDBOX HTML OUTSIDE THE CONTAINER -->
-
-
 {% endblock %}
 
 {% block styles %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -193,6 +193,11 @@ $(document).ready(function() {
   $(document).ready(function() {
       $.get('{% url "onadata.apps.restservice.views.add_service" content_user.username xform.id_string %}', function(data){
           $('#restservice_tab').html(data);
+          // hide whole section if there are no rest services
+          // as the legacy code here only allows for deleting
+          if ($('#restservice_tab').find('#restservice_list li').length === 0) {
+              $('.settings__rest-services').hide();
+          }
       });
   });
 </script>

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -79,16 +79,6 @@
 
         </div>  <!-- END .settings__general -->
 
-        <div class="settings__delete-project">
-          <h2 class="settings__group-label">
-            Delete project with all data and its form
-          </h2>
-          <button data-backdrop="true" data-keyboard="true" class="single-project__button single-project__button-delete">
-              {% trans "Delete" %}
-          </button>
-
-        </div>
-
         {% if is_owner %}
         <div class="settings__rest-services">
             <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
@@ -96,27 +86,6 @@
             </div>
         </div>
         {% endif %}
-    </div>
-  </div>
-  {% endif %}
-
-  <!-- Delete form (in vex window) -->
-  {% if is_owner %}
-  <div class="kc-hide">
-    <div id="delete-form">
-        <form action="{% url "onadata.apps.logger.views.delete_xform" username=user.username id_string=xform.id_string %}" method="post">
-        {% csrf_token %}
-            <div class="vex-header">
-                <h3>{% trans "Delete Confirmation" %}</h3>
-            </div>
-            <div class="vex-kobo-body">
-                <p>{% blocktrans with title=xform.title nb_sub=xform.submission_count|intcomma %}Are you sure you want to delete the form '{{ title }}'? This form has <strong>{{ nb_sub }}</strong> submissions associated with it that will also be deleted. If you are unsure about deleting this form press 'Cancel' and consider 'Archiving' the form instead.{% endblocktrans %}</p>
-            </div>
-            <div class="vex-footer">
-                <a href="#" onclick="vex.close(vexDelete.data().vex.id)" class="btn btn-transparent">{% trans "Cancel" %}</a>
-                <button class="btn btn-danger form-submit">Delete</button>
-            </div>
-        </form>
     </div>
   </div>
   {% endif %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -63,7 +63,7 @@
 
       {% if is_owner %}
       <div class="settings__rest-services">
-          <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
+          <h2 class="settings__group-label">{% trans "Legacy Rest Services" %}</h2>
           <div id='restservice_tab'>
             {% trans "Loading..." %}
           </div>

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -7,6 +7,7 @@
   <!-- a temporary way to hide the kobocat deprecated features -->
   <style type="text/css">
   .kc-hide { display: none !important; }
+  #addserviceform { display: none !important; }
   </style>
 
 {% endblock %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -9,7 +9,6 @@
   .kc-hide { display: none !important; }
   #addserviceform { display: none !important; }
   </style>
-
 {% endblock %}
 
 {% block content %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -65,6 +65,7 @@
       <div class="settings__rest-services">
           <h2 class="settings__group-label">{% trans "Rest Services" %}</h2>
           <div id='restservice_tab'>
+            {% trans "Loading..." %}
           </div>
       </div>
       {% endif %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -33,13 +33,6 @@
           </h2>
 
           <div class="settings__form-item">
-            <label class="settings__form-label">
-              {% trans "Accept Submissions" %}
-            </label>
-            <label><input id="active-form" type="checkbox" class="ios-switch" {% if xform.downloadable %} checked=""{% endif %} data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}"><div class="switch"></div></label>
-          </div>
-
-          <div class="settings__form-item">
             <label class="settings__form-label">Existing Form Files</label>
             <ul class="settings__files">
               {% for media in media_upload %}

--- a/templates/show_form_settings.html
+++ b/templates/show_form_settings.html
@@ -25,7 +25,7 @@
   {% if is_owner %}
   <div class="container__wide">
     <div class="single-project__settings--iframe">
-      <div class="settings__left">
+
         <div class="settings__general">
           <h2 class="settings__group-label">
             {% trans "Form Settings" %}
@@ -95,68 +95,6 @@
             </div>
         </div>
         {% endif %}
-
-      </div>
-
-      <div class="settings__right">
-        <h2 class="settings__group-label">
-          How would you like to share your project
-        </h2>
-
-        <div class="settings__form-item">
-          <label class="settings__form-label">
-            Share Project Publicly
-          </label>
-          <label>
-            <input id="form-shared" type="checkbox" class="ios-switch" {% if xform.shared %} checked=""{% endif %} data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}" >
-            <div title="{% trans "Allow anyone from the web to view this page." %}" class="poshytip switch"></div>
-          </label>
-        </div>
-
-        <div class="settings__form-item">
-          <label class="settings__form-label">
-            Share Data Publicly
-          </label>
-          <label>
-            <input id="data-shared" type="checkbox" class="ios-switch" {% if xform.shared_data %} checked=""{% endif %} data-url="{% url "onadata.apps.main.views.edit" content_user.username xform.id_string %}">
-            <div title="{% trans "Allow anyone from the web to inspect this project&rsquo;s data." %}" class="poshytip switch"></div>
-          </label>
-        </div>
-
-        <div class="settings__form-item">
-          <label class="settings__form-label">
-            Share project with other users
-          </label>
-          {% if public_link %}
-          {% url "onadata.apps.main.views.show" xform.uuid as form_url %}
-          {% blocktrans %}Sharing by link is <strong>on with URL <a href="{{ form_url }}">{{ base_url }}{{ form_url }}</a></strong>{% endblocktrans %}
-          {% else %}
-          {% blocktrans %}Sharing by link is <strong>off</strong>{% endblocktrans %}
-          {% endif %}
-          </strong>
-          <form action="{% url "onadata.apps.main.views.set_perm" content_user.username xform.id_string %}" method="post">
-              {% csrf_token %}
-              <input type="hidden" name="perm_type" value="link"/>
-              <input type="hidden" name="for_user" value="toggle"/>
-              <input type="submit" class="single-project__button" value="{% if public_link %}{% trans "Turn off" %}{% else %}{% trans "Turn on" %}{% endif %}" />
-          </form>
-          {% if users_with_perms|length %}
-          <ul>
-              {% for user, perms in users_with_perms %}
-              <li>{{ user }}: {{ perms }}</li>
-              {% endfor %}
-          </ul>
-          {% endif %}
-          <form action="{% url "onadata.apps.main.views.set_perm" content_user.username xform.id_string %}" method="post">
-              {% csrf_token %}
-              <table class="narrow-labels">
-              {{ permission_form.as_table }}
-              </table>
-              <input type="submit" class="single-project__button" value="{% trans 'Save Permissions' %}" />
-          </form>
-        </div>
-
-      </div>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
Done:

- Remove entire right column
- Remove "Accept Submissions" (moved to KPI)
- Remove delete button (moved to KPI)
- Remove "add REST Service" form (list is still there)

Part of https://github.com/kobotoolbox/kobocat/issues/488
Fixes https://github.com/kobotoolbox/kpi/issues/2094